### PR TITLE
feat: minimum brightness for initial random palette

### DIFF
--- a/docs/src/components/theme/theme.ts
+++ b/docs/src/components/theme/theme.ts
@@ -2,6 +2,8 @@ import { Theme, ThemeUpdateEvent } from '@colormotion';
 
 export const theme = new Theme({
     maxNumberOfColors: 7,
+    nColors: 5,
+    minBrightness: 0.6,
 });
 
 /**

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -32,6 +32,12 @@ export type InitialThemeColors =
            * Defaults to 5.
            */
           nColors?: number;
+          /**
+           * The minimum brightness for the random colors.
+           * Scale from 0 to 1.
+           * Defaults to 0.
+           */
+          minBrightness?: number;
       };
 
 export type ThemeConfig = InitialThemeColors & {
@@ -162,14 +168,19 @@ export class Theme {
                     (config && 'nColors' in config
                         ? config.nColors
                         : undefined) ?? 5;
+                const minBrightness =
+                    config && 'minBrightness' in config
+                        ? config.minBrightness
+                        : 0;
                 this.palette = new ColorPalette({
-                    colors: Array.from({ length: nColors }, () =>
-                        chroma.random(),
-                    ),
+                    colors: ['black'],
                     mode: this.mode,
                     nSteps: this.nSteps,
                     deltaEThreshold: config?.deltaEThreshold,
                     maxNumberOfColors: this.maxNumberOfColors,
+                }).randomize({
+                    minBrightness,
+                    nColors,
                 });
             }
         }

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -172,13 +172,11 @@ export class Theme {
                     config && 'minBrightness' in config
                         ? config.minBrightness
                         : 0;
-                this.palette = new ColorPalette({
-                    colors: ['black'],
+                this.palette = ColorPalette.random({
                     mode: this.mode,
                     nSteps: this.nSteps,
                     deltaEThreshold: config?.deltaEThreshold,
                     maxNumberOfColors: this.maxNumberOfColors,
-                }).randomize({
                     minBrightness,
                     nColors,
                 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    server: {
+        watch: {
+            followSymlinks: false,
+        },
+    },
     test: {
+        root: 'tests',
+        exclude: ['**/docs/*', '**/dist/*'],
+        fileParallelism: false,
+        testTimeout: 1000,
+        hookTimeout: 1000,
         coverage: {
             provider: 'v8',
             exclude: [


### PR DESCRIPTION
Allow setting a minimum brightness for a `Theme` initialized with random colors.